### PR TITLE
Fix library loading for Darwin system (arm)

### DIFF
--- a/src/extr/sdl-image/lib.lisp
+++ b/src/extr/sdl-image/lib.lisp
@@ -8,10 +8,11 @@
 (cffi:define-foreign-library libsdl3-image
   (:darwin (:or (:framework "SDL3_image") (:default "libSDL3_image")))
   (:unix (:or "libSDL3_image.so" "libSDL3_image.so.0" "libSDL3_image.so.0.2.1"))
+  #+(or x86 x86-64)
   (:windows #.(system-relative-namestring
-	       :sdl3
-	       #+x86 "src/extr/sdl-image/lib/windows/x86/SDL3_image.dll"
-	       #+x86-64 "src/extr/sdl-image/lib/windows/x86-64/SDL3_image.dll"))
+               :sdl3
+               #+x86 "src/extr/sdl-image/lib/windows/x86/SDL3_image.dll"
+               #+x86-64 "src/extr/sdl-image/lib/windows/x86-64/SDL3_image.dll"))
   (t (:default "libSDL3")))
 
 (cffi:use-foreign-library libsdl3-image)

--- a/src/extr/sdl-ttf/lib.lisp
+++ b/src/extr/sdl-ttf/lib.lisp
@@ -6,7 +6,7 @@
     (namestring (asdf:system-relative-pathname system name))))
 
 (cffi:define-foreign-library libsdl3-ttf
-  (:darwin (:or (:framework "SDL3_ttf") (:default "libSDL3-ttf")))
+  (:darwin (:or (:framework "SDL3_ttf") (:default "libSDL3_ttf")))
   (:unix (:or "libSDL3_ttf.so" "libSDL3_ttf.so.0" "libSDL3_ttf.so.0.1.1"))
   #+(or x86 x86-64)
   (:windows #.(system-relative-namestring

--- a/src/extr/sdl-ttf/lib.lisp
+++ b/src/extr/sdl-ttf/lib.lisp
@@ -8,10 +8,11 @@
 (cffi:define-foreign-library libsdl3-ttf
   (:darwin (:or (:framework "SDL3_ttf") (:default "libSDL3-ttf")))
   (:unix (:or "libSDL3_ttf.so" "libSDL3_ttf.so.0" "libSDL3_ttf.so.0.1.1"))
+  #+(or x86 x86-64)
   (:windows #.(system-relative-namestring
-	       :sdl3
-	       #+x86 "src/extr/sdl-ttf/lib/windows/x86/SDL3_ttf.dll"
-	       #+x86-64 "src/extr/sdl-ttf/lib/windows/x86-64/SDL3_ttf.dll"))
+               :sdl3
+               #+x86 "src/extr/sdl-ttf/lib/windows/x86/SDL3_ttf.dll"
+               #+x86-64 "src/extr/sdl-ttf/lib/windows/x86-64/SDL3_ttf.dll"))
   (t (:default "libSDL3")))
 
 (cffi:use-foreign-library libsdl3-ttf)

--- a/src/lib.lisp
+++ b/src/lib.lisp
@@ -8,10 +8,11 @@
 (cffi:define-foreign-library libsdl3
   (:darwin (:or (:framework "SDL3") (:default "libSDL3")))
   (:unix (:or "libSDL3.so" "libSDL3.so.0" "libSDL3.so.0.1.11"))
+  #+(or x86 x86-64)
   (:windows #.(system-relative-namestring
-	       :sdl3
-	       #+x86 "lib/windows/x86/SDL3.dll"
-	       #+x86-64 "lib/windows/x86-64/SDL3.dll"))
+               :sdl3
+               #+x86 "lib/windows/x86/SDL3.dll"
+               #+x86-64 "lib/windows/x86-64/SDL3.dll"))
   (t (:default "libSDL3")))
 
 (cffi:use-foreign-library libsdl3)


### PR DESCRIPTION
1. When specifying windows library there is only x86 and x86-64 options. And thus in ARM system this gives an error. 

    Solution: Added proper feature flags

2. The ttf library name for darwin system has a typo