### PR TITLE
Use main thread and float masks when running in darwin system

### DIFF
--- a/sdl3.asd
+++ b/sdl3.asd
@@ -3,8 +3,12 @@
   :author "YJC"
   :license ""
   :depends-on (:alexandria
-	       :defclass-std
-	       :cffi-libffi)
+               :defclass-std
+               :cffi-libffi
+               #+darwin
+               :trivial-main-thread
+               #+darwin
+               :float-features)
   :components ((:module "src"
 		:components
 		((:file "package")

--- a/src/main/wrap.lisp
+++ b/src/main/wrap.lisp
@@ -14,14 +14,21 @@ argv -> list of argument"
   (cffi:with-foreign-object (vargs :string (length args))
     (dotimes (i (length args))
       (cffi:lisp-string-to-foreign (nth i args)
-				   (cffi:mem-aptr vargs :string i)
-				   (length (nth i args))))
-    (%run-app (length args)
-	      (if args
-		  (cffi:mem-aptr vargs :string)
-		  (cffi:null-pointer))
-	      (cffi:get-callback callback)
-	      (cffi:null-pointer))))
+                                   (cffi:mem-aptr vargs :string i)
+                                   (length (nth i args))))
+    (flet ((thunk ()
+             (%run-app (length args)
+                       (if args
+                           (cffi:mem-aptr vargs :string)
+                           (cffi:null-pointer))
+                       (cffi:get-callback callback)
+                       (cffi:null-pointer))))
+      #+darwin
+      (trivial-main-thread:with-body-in-main-thread (:blocking t)
+        (float-features:with-float-traps-masked t
+          (thunk)))
+      #-darwin
+      (thunk))))
 (export 'run-app)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -79,14 +86,21 @@ result -> the result code that terminated the app (success or failure).
   (cffi:with-foreign-object (vargs :string (length args))
     (dotimes (i (length args))
       (cffi:lisp-string-to-foreign (nth i args)
-				   (cffi:mem-aptr vargs :string i)
-				   (length (nth i args))))
-    (%enter-app-main-callbacks (length args)
-			       (if args
-				   (cffi:mem-aptr vargs :string)
-				   (cffi:null-pointer))
-			       (cffi:get-callback appinit)
-			       (cffi:get-callback appiter)
-			       (cffi:get-callback appevent)
-			       (cffi:get-callback appquit))))
+                                   (cffi:mem-aptr vargs :string i)
+                                   (length (nth i args))))
+    (flet ((thunk ()
+             (%enter-app-main-callbacks (length args)
+                                        (if args
+                                            (cffi:mem-aptr vargs :string)
+                                            (cffi:null-pointer))
+                                        (cffi:get-callback appinit)
+                                        (cffi:get-callback appiter)
+                                        (cffi:get-callback appevent)
+                                        (cffi:get-callback appquit))))
+      #+darwin
+      (trivial-main-thread:with-body-in-main-thread (:blocking t)
+        (float-features:with-float-traps-masked t
+          (thunk)))
+      #-darwin
+      (thunk))))
 (export 'enter-app-main-callbacks)


### PR DESCRIPTION
In MacOS the UI functions MUST be called from the main thread.

I have added `trivial-main-thread` portability library as a dependency and used it in `enter-app-main-callbacks`.

Also, floating point traps need to be masked (at least in MacOS where I have tested). Please see https://bugs.launchpad.net/sbcl/+bug/2061291 for some details on related issue. For portability, I added `float-features` library.