### PR TITLE
Fix sdl->lsp function

### DIFF
--- a/src/translate-fun.lisp
+++ b/src/translate-fun.lisp
@@ -1,35 +1,37 @@
 (in-package :sdl3)
 
-
-(defparameter *key-world* '("GL" "EGL"))
-
-(defun get-word-until-lower-case (str
-				  &aux (rst ""))
-  (dotimes (i (length str))
-    (cond ((lower-case-p (char str (1+ i)))
-	   (return-from get-word-until-lower-case (values rst (- i 1))))
-	  (t (setf rst (string+ rst (char str i))))))
-  (values rst (length str)))
+(defun any-prefix-p (string prefixes)
+  "Does string have any of the prefix?
+If so, return that prefix"
+  (some (lambda (prefix)
+          (and (uiop:string-prefix-p prefix string) prefix))
+        prefixes))
 
 (defun sdl->lsp (str)
-  "please optimize it"
   (let ((name (subseq str 4 (length str)))
-	(lsp-name ""))
-    (do ((i 0 (1+ i)))
-	((>= i (length name)) lsp-name)
-      (setf lsp-name
-	    (string+ lsp-name 
-		     (cond ((= i 0) (char-downcase (char name i)))
-			   ((and (upper-case-p (char name i))
-				 (upper-case-p (char name (+ i 1))))
-			    ;; just use in gpu file fix it
-			    (multiple-value-bind (rst next-i)
-				(get-word-until-lower-case (subseq name i))
-			      (setf i (+ i next-i))
-			      (string+ #\- (string-downcase rst))))
-			   ((upper-case-p (char name i))
-			    (string+ #\- (char-downcase (char name i))))
-			   (t (char name i))))))))
+        (special-substrings (list "GPU" "YUV" "NV" "IO" "RW" "GUID" "SF"))
+        char
+        prefix-match)
+    (with-output-to-string (str)
+      (do ((i 0 (1+ i)))
+          ((>= i (length name)))
+        (setf char (char name i))
+        (cond ((or (lower-case-p char)
+                   (digit-char-p char)
+                   (char= #\- char))
+               (write-char char str))
+              ((and (upper-case-p char)
+                    (setf prefix-match (any-prefix-p (subseq name i)
+                                                     special-substrings)))
+               (unless (eql i 0)
+                 (write-char #\- str))
+               (write-string (string-downcase prefix-match) str)
+               (incf i (1- (length prefix-match))))
+              ((upper-case-p char)
+               (unless (eql i 0)
+                 (write-char #\- str))
+               (write-char (char-downcase char) str))
+              (t (error "Unable to handle at char: ~a" char)))))))
 
 (defmacro defexport-fun (name ret &body body
 			 &aux (lsp-name (when (atom name)


### PR DESCRIPTION
Fix sdl->lsp function for all special cases currently used in the codebase. 

I recorded all the input output mapping from the original sdl->lsp function and used that as test cases.
```lisp
(defun test-sdl->lsp ()
  (declare (optimize (debug 3)))
  (loop for (in . out) in (uiop:read-file-form "./sdl-lsp-tests.txt") do
        (unless (string= out (sdl3::sdl->lsp in))
          (format t "~a -> ~a != ~a~%" in (sdl3::sdl->lsp in) out))))
```

The new code produces different results than the previous code for the following cases only:

- SDL_GPUTextureSupportsSampleCount -> gpu-texture-supports-sample-count != g-pu-texture-supports-sample-count
- SDL_GPUTextureSupportsFormat -> gpu-texture-supports-format != g-pu-texture-supports-format
- SDL_GPUSupportsProperties -> gpu-supports-properties != g-pu-supports-properties
- SDL_GPUSupportsShaderFormats -> gpu-supports-shader-formats != g-pu-supports-shader-formats


[sdl-lsp-tests.txt](https://github.com/user-attachments/files/18717178/sdl-lsp-tests.txt)