### PR TITLE
Define corresponding type when defining cenum and bitfield

### DIFF
--- a/src/assert/type.lisp
+++ b/src/assert/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defcenum assert-state 
+(defcenum assert-state 
   :retry
   :break
   :abort

--- a/src/asyncio/type.lisp
+++ b/src/asyncio/type.lisp
@@ -1,12 +1,12 @@
 (in-package :sdl3)
 
-(cffi:defcenum async-io-task-type
+(defcenum async-io-task-type
   :read
   :write
   :close)
 
 
-(cffi:defcenum async-io-result
+(defcenum async-io-result
   :asyncio_complete
   :asyncio_failure
   :asyncio_canceled)

--- a/src/audio/type.lisp
+++ b/src/audio/type.lisp
@@ -2,7 +2,7 @@
 
 (cffi:defctype audio-device-id :uint32)
 
-(cffi:defcenum audio-format
+(defcenum audio-format
   (:unknown  #x0000)
   (:u8       #x0008)
   (:s8       #x8008) 

--- a/src/blendmode/type.lisp
+++ b/src/blendmode/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defcenum blend-factor
+(defcenum blend-factor
   (:blendfactor-zero                #x1)
   (:blendfactor-one                 #x2)
   (:blendfactor-src-color           #x3)
@@ -12,14 +12,14 @@
   (:blendfactor-dst-alpha           #x9)
   (:blendfactor-one-minus-dst-alpha #xa))
 
-(cffi:defcenum blend-operation
+(defcenum blend-operation
   (:blendoperation-add              #x1)
   (:blendoperation-subtract         #x2)
   (:blendoperation-rev-subtract     #x3)
   (:blendoperation-minimum          #x4)
   (:blendoperation-maximum          #x5))
 
-(cffi:defbitfield blend-mode 
+(defbitfield blend-mode 
   (:sdl-blendmode-none                  #x00000000)
   (:sdl-blendmode-blend                 #x00000001)
   (:sdl-blendmode-blend-premultiplied   #x00000010)

--- a/src/camera/type.lisp
+++ b/src/camera/type.lisp
@@ -10,7 +10,7 @@
   (framerate-numerator :int)
   (framerate-denominator :int))
 
-(cffi:defcenum camera-position
+(defcenum camera-position
   :unknown
   :front-facing
   :back-facing)

--- a/src/dialog/type.lisp
+++ b/src/dialog/type.lisp
@@ -4,7 +4,7 @@
   (name :string)
   (pattern :string))
 
-(cffi:defcenum file-dialog-type
+(defcenum file-dialog-type
   :openfile
   :savefile
   :openfolder)

--- a/src/events/type.lisp
+++ b/src/events/type.lisp
@@ -5,7 +5,7 @@
   (reserved :uint32)
   (timestamp :uint64))
 
-(cffi:defcenum event-type
+(defcenum event-type
   (:first 0)
   (:quit #x100)
   :terminating
@@ -220,7 +220,7 @@
   (x :float)
   (y :float))
 
-(cffi:defcenum mouse-wheel-direction
+(defcenum mouse-wheel-direction
   :normal
   :flipped)
 
@@ -404,7 +404,7 @@
   (window-id window-id)
   (which pen-id))
 
-(cffi:defbitfield pen-input-flags
+(defbitfield pen-input-flags
   (:down #x1)
   (:button-1 #x2)
   (:button-2 #x4)
@@ -447,7 +447,7 @@
   (button :uint8)
   (down :bool))
 
-(cffi:defcenum pen-axis
+(defcenum pen-axis
   :pressure
   :xtilt
   :ytilt
@@ -535,7 +535,7 @@
   (padding :uint8 :count 128))
 (export 'event)
 
-(cffi:defcenum event-action 
+(defcenum event-action 
   :addevent
   :peekevent
   :getevent)

--- a/src/extr/sdl-image/package.lisp
+++ b/src/extr/sdl-image/package.lisp
@@ -1,3 +1,3 @@
 (defpackage :sdl3-image
-  (:use #:cl))
-
+  (:use #:cl)
+  (:import-from :sdl3 :defcenum :defbitfield))

--- a/src/extr/sdl-ttf/package.lisp
+++ b/src/extr/sdl-ttf/package.lisp
@@ -1,3 +1,4 @@
 (defpackage :sdl3-ttf
-  (:use #:cl))
+  (:use #:cl)
+  (:import-from :sdl3 :defcenum :defbitfield))
 

--- a/src/extr/sdl-ttf/type.lisp
+++ b/src/extr/sdl-ttf/type.lisp
@@ -1,33 +1,33 @@
 (in-package :sdl3-ttf)
 
-(cffi:defbitfield font-style-flags 
+(defbitfield font-style-flags 
   (:normal        #x00)
   (:bold          #x01)
   (:italic        #x02)
   (:underline     #x04)
   (:strikethrough #x08))
 
-(cffi:defcenum hinting-flags
+(defcenum hinting-flags
   (:normal 0)
   :light
   :mono
   :none
   :light-subpixel)
 
-(cffi:defcenum horizontal-alignment
+(defcenum horizontal-alignment
   (:invalid -1)
   (:left)
   (:center)
   (:right))
 
-(cffi:defcenum direction
+(defcenum direction
  (:INVALID 0)
  (:LTR 4)
  :RTL
  :TTB
  :BTT)
 
-(cffi:defcenum image-type
+(defcenum image-type
   (:INVALID)
   (:ALPHA)
   (:COLOR)
@@ -116,12 +116,12 @@
 
 (export '(gpu-atlas-draw-sequence %atlas-texture %xy %uv %num-vertices %indices %image-type %next))
 
-(cffi:defcenum gpu-text-engine-winding
+(defcenum gpu-text-engine-winding
   (:invalid -1)
   :clockwise
   :counter-clockwise)
 
-(cffi:defbitfield sub-string-flags
+(defbitfield sub-string-flags
   (:direction-mask    #x000000ff)
   (:text-start        #x00000100)
   (:line-start        #x00000200)

--- a/src/filesystem/type.lisp
+++ b/src/filesystem/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defcenum folder 
+(defcenum folder 
   :home         
   :desktop      
   :documents    
@@ -14,7 +14,7 @@
   :videos       
   :count)
 
-(cffi:defcenum path-type
+(defcenum path-type
   :none
   :file
   :directory
@@ -27,5 +27,5 @@
   (modify-time stime)
   (access-time stime))
 
-(cffi:defbitfield glob-flags
+(defbitfield glob-flags
   (:glob-caseinsensitive 1))

--- a/src/gamepad/type.lisp
+++ b/src/gamepad/type.lisp
@@ -2,7 +2,7 @@
 
 (cffi:defctype joystick-id :uint32)
 
-(cffi:defcenum gamepad-type
+(defcenum gamepad-type
   (:unknown 0)
   :standard
   :xbox360
@@ -16,13 +16,13 @@
   :nintendo-switch-joycon-pair
   :count)
 
-(cffi:defcenum joystick-connection-state
+(defcenum joystick-connection-state
   (:invalid  -1)
   :unknown
   :wired
   :wireless)
 
-(cffi:defcenum gamepad-binding-type
+(defcenum gamepad-binding-type
   (:none 0)
   :button
   :axis
@@ -40,7 +40,7 @@
   (axis (:struct %gamepad-biding-input-axis))
   (hat (:struct %gamepad-biding-input-hat)))
 
-(cffi:defcenum gamepad-button
+(defcenum gamepad-button
   (:invalid -1)
   :south
   :east
@@ -69,7 +69,7 @@
   :misc5
   :misc6
   :count)
-(cffi:defcenum gamepad-axis
+(defcenum gamepad-axis
   (:invalid -1)
   :leftx
   :lefty
@@ -90,7 +90,7 @@
   (output-type gamepad-binding-type)
   (output (:union %gamepad-binding-output)))
 
-(cffi:defcenum gamepad-button-label
+(defcenum gamepad-button-label
   :unknown
   :a
   :b

--- a/src/gpu/type.lisp
+++ b/src/gpu/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defbitfield gpu-shader-format
+(defbitfield gpu-shader-format
   (:invalid  #x0)
   (:private  #x1)
   (:spirv    #x2)
@@ -25,7 +25,7 @@
   (threadcount-z :uint32)
   (props properties-id))
 
-(cffi:defcenum gpu-vertex-input-rate
+(defcenum gpu-vertex-input-rate
   :vertex
   :instance)
 
@@ -35,7 +35,7 @@
   (input-rate gpu-vertex-input-rate)
   (instance-step-rate :uint32))
 
-(cffi:defcenum gpu-vertex-element-format
+(defcenum gpu-vertex-element-format
   :invalid
   :int
   :int2
@@ -80,23 +80,23 @@
   (vertex-attributes (:pointer (:struct gpu-vertex-attribute)))
   (num-vertex-attributes :uint32))
 
-(cffi:defcenum gpu-primitive-type
+(defcenum gpu-primitive-type
   :trianglelist
   :trianglestrip
   :linelist
   :linestrip
   :pointlist)
 
-(cffi:defcenum gpu-fill-mode
+(defcenum gpu-fill-mode
   :fill
   :line)
 
-(cffi:defcenum gpu-cull-mode
+(defcenum gpu-cull-mode
   :none
   :front
   :back)
 
-(cffi:defcenum gpu-front-face
+(defcenum gpu-front-face
   :counter-clockwise
   :clockwise)
 
@@ -112,7 +112,7 @@
   (padding1 :uint8)
   (padding2 :uint8))
 
-(cffi:defcenum gpu-sample-count
+(defcenum gpu-sample-count
   :1
   :2
   :4
@@ -126,7 +126,7 @@
   (padding2 :uint8)
   (padding3 :uint8))
 
-(cffi:defcenum gpu-compare-op
+(defcenum gpu-compare-op
   :invalid
   :never
   :less
@@ -137,7 +137,7 @@
   :greater-or-equal
   :always)
 
-(cffi:defcenum gpu-stencil-op
+(defcenum gpu-stencil-op
   :invalid
   :keep
   :zero
@@ -167,7 +167,7 @@
   (padding2 :uint8)
   (padding3 :uint8))
 
-(cffi:defcenum gpu-texture-format
+(defcenum gpu-texture-format
   :invalid
   :a8-unorm
   :r8-unorm
@@ -274,7 +274,7 @@
   :astc-12x10-float
   :astc-12x12-float)
 
-(cffi:defcenum gpu-blend-factor
+(defcenum gpu-blend-factor
   :invalid
   :zero
   :one
@@ -290,7 +290,7 @@
   :one-minus-constant-color
   :src-alpha-saturate)
 
-(cffi:defcenum gpu-blend-op
+(defcenum gpu-blend-op
  :invalid
  :add
  :subtract
@@ -298,7 +298,7 @@
  :min
  :max)
 
-(cffi:defbitfield color-component-flags
+(defbitfield color-component-flags
   (:r #x1)
   (:g #x2)
   (:b #x4)
@@ -341,15 +341,15 @@
   (target-info (:struct gpu-graphics-pipeline-target-info))
   (props properties-id))
 
-(cffi:defcenum gpu-filter
+(defcenum gpu-filter
   :nearest
   :linear)
 
-(cffi:defcenum gpu-sampler-mipmap-mode
+(defcenum gpu-sampler-mipmap-mode
   :nearest
   :linear)
 
-(cffi:defcenum gpu-sampler-address-mode
+(defcenum gpu-sampler-address-mode
   :repeat
   :mirrored-repeat
   :clamp-to-edge)
@@ -372,7 +372,7 @@
   (padding2 :uint8)
   (props properties-id))
 
-(cffi:defcenum gpu-shader-stage
+(defcenum gpu-shader-stage
   :vertex
   :fragment)
 
@@ -388,14 +388,14 @@
   (num-uniform-buffers :uint32)
   (props properties-id))
 
-(cffi:defcenum gpu-texture-type
+(defcenum gpu-texture-type
   :2d
   :2d-array
   :3d
   :cube
   :cube-array)
 
-(cffi:defbitfield gpu-texture-usage-flags
+(defbitfield gpu-texture-usage-flags
   (:sampler                                 #x1)
   (:color-target                            #x2)
   (:depth-stencil-target                    #x4)
@@ -415,7 +415,7 @@
   (sample-count gpu-sample-count)
   (props properties-id))
 
-(cffi:defbitfield gpu-buffer-usage-flags
+(defbitfield gpu-buffer-usage-flags
   (:vertex                      #x1)
   (:index                       #x2)
   (:indirect                    #x4)
@@ -428,7 +428,7 @@
   (size :uint32)
   (props properties-id))
 
-(cffi:defcenum gpu-transfer-buffer-usage
+(defcenum gpu-transfer-buffer-usage
   :upload
   :download)
 
@@ -437,12 +437,12 @@
   (size :uint32)
   (props properties-id))
 
-(cffi:defcenum gpu-load-op
+(defcenum gpu-load-op
   :load
   :clear
   :dont-care)
 
-(cffi:defcenum gpu-store-op
+(defcenum gpu-store-op
   :load
   :dont-care
   :reslove
@@ -487,7 +487,7 @@
   (buffer :pointer)
   (offset :uint32))
 
-(cffi:defcenum gpu-index-element-size
+(defcenum gpu-index-element-size
   :16bit
   :32bit)
 
@@ -570,13 +570,13 @@
   (padding2 :uint8)
   (padding3 :uint8))
 
-(cffi:defcenum gpu-swapchain-composition
+(defcenum gpu-swapchain-composition
   :sdr
   :sdr-linear
   :hdr-extended-linear
   :hdr10-st2084)
 
-(cffi:defcenum gpu-present-mode
+(defcenum gpu-present-mode
   :vsync
   :immediate
   :mailbox)

--- a/src/hints/type.lisp
+++ b/src/hints/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defcenum hit-priority
+(defcenum hit-priority
   :default
   :normal
   :override)

--- a/src/init/type.lisp
+++ b/src/init/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defbitfield init-flags
+(defbitfield init-flags
   (:audio      #x00000010)
   (:video      #x00000020)
   (:joystick   #x00000200)

--- a/src/iostream/type.lisp
+++ b/src/iostream/type.lisp
@@ -9,7 +9,7 @@
   (flush :pointer)
   (close :pointer))
 
-(cffi:defcenum io-status
+(defcenum io-status
   :ready
   :error
   :eof
@@ -17,7 +17,7 @@
   :readonly
   :writeonly)
 
-(cffi:defcenum io-whence
+(defcenum io-whence
   :set
   :cur
   :end)

--- a/src/joystick/type.lisp
+++ b/src/joystick/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defcenum joystick-type
+(defcenum joystick-type
   :unknown
   :gamepad
   :wheel
@@ -13,7 +13,7 @@
   :throttle
   :count)
 
-(cffi:defcenum joystick-connection-state
+(defcenum joystick-connection-state
   (:invalid -1)
   :unknown
   :wired

--- a/src/keyboard/type.lisp
+++ b/src/keyboard/type.lisp
@@ -2,7 +2,7 @@
 
 (cffi:defctype keyboard-id :uint32)
 
-(cffi:defcenum scancode
+(defcenum scancode
   (:unknown 0)
   (:a 4)
   (:b 5)
@@ -253,7 +253,7 @@
   (:count 512))
 
 
-(cffi:defbitfield keycode
+(defbitfield keycode
   (:extended-mask #x20000000)
   (:scancode-mask #x40000000)
   (:unknown #x00000000)
@@ -514,7 +514,7 @@
   (:rhyper #x20000007)
   )
 
-(cffi:defbitfield (keymod :uint16)
+(defbitfield (keymod :uint16)
   (:none #x0000)
   (:lshift #x0001)
   (:rshift #x0002)

--- a/src/load-docstring.lisp
+++ b/src/load-docstring.lisp
@@ -15,7 +15,7 @@
                      ((or (eql type :enum)
                           (eql type :bitfield)
                           (eql type :typedef))
-                      (setf (get symbol :doc) docstring))
+                      (setf (documentation symbol 'type) docstring))
                      ((eql type :struct)
                       (setf (documentation symbol 'type) docstring))
                      (t

--- a/src/log/type.lisp
+++ b/src/log/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defcenum log-priority
+(defcenum log-priority
  :invalid
  :trace
  :verbose

--- a/src/main/type.lisp
+++ b/src/main/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defcenum app-result
+(defcenum app-result
   :continue
   :success
   :failure)

--- a/src/messagebox/type.lisp
+++ b/src/messagebox/type.lisp
@@ -1,13 +1,13 @@
 (in-package :sdl3)
 
-(cffi:defbitfield message-box-flags 
+(defbitfield message-box-flags 
   (:messagebox-error                    #x00000010)
   (:messagebox-warning                  #x00000020)
   (:messagebox-information              #x00000040)
   (:messagebox-buttons-left-to-right    #x00000080)
   (:messagebox-buttons-right-to-left    #x00000100))
 
-(cffi:defbitfield message-box-button-flags
+(defbitfield message-box-button-flags
   (:messagebox-button-returnkey-default #x00000001)
   (:messagebox-button-escapekey-default #x00000002))
 
@@ -16,7 +16,7 @@
   (g :uint8)
   (b :uint8))
 
-(cffi:defcenum message-box-color-type 
+(defcenum message-box-color-type 
   :messagebox-color-background
   :messagebox-color-text
   :messagebox-color-button-border

--- a/src/mouse/type.lisp
+++ b/src/mouse/type.lisp
@@ -2,7 +2,7 @@
 
 (cffi:defctype mouse-id :uint32)
 
-(cffi:defbitfield mouse-button-flags
+(defbitfield mouse-button-flags
   (:button-left 1)
   (:button-middle 2)
   (:button-right 3)
@@ -14,7 +14,7 @@
   (:button-x1mask 8)
   (:button-x2mask 16))
 
-(cffi:defcenum system-cursor
+(defcenum system-cursor
   :default      
   :text         
   :wait         

--- a/src/pixels/type.lisp
+++ b/src/pixels/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defcenum pixel-format
+(defcenum pixel-format
   (:unknown 0)
   (:index1lsb #x11100100)
   (:index1msb #x11200100)
@@ -112,7 +112,7 @@
   (version :uint32)
   (refcount :int))
 
-(cffi:defcenum colorspace
+(defcenum colorspace
   (:unknown 0)
   (:srgb #x120005a0)
   (:srgb-linear #x12000500)

--- a/src/power/type.lisp
+++ b/src/power/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defcenum power-state
+(defcenum power-state
   (:powerstate-error  -1)
   :powerstate-unknown
   :powerstate-on-battery

--- a/src/properties/type.lisp
+++ b/src/properties/type.lisp
@@ -2,7 +2,7 @@
 
 (cffi:defctype properties-id :uint32)
 
-(cffi:defcenum property-type
+(defcenum property-type
   :invalid
   :pointer
   :string

--- a/src/render/type.lisp
+++ b/src/render/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defcenum texture-access
+(defcenum texture-access
   :static
   :streaming
   :target)
@@ -11,7 +11,7 @@
   (h :int)
   (refcount :int))
 
-(cffi:defcenum renderer-logical-presentation
+(defcenum renderer-logical-presentation
   :disabled
   :stretch
   :letterbox

--- a/src/sensor/type.lisp
+++ b/src/sensor/type.lisp
@@ -2,7 +2,7 @@
 
 (cffi:defctype sensor-id :uint32)
 
-(cffi:defcenum sensor-type 
+(defcenum sensor-type 
   (:invalid -1)
   :unknown
   :accel

--- a/src/surface/type.lisp
+++ b/src/surface/type.lisp
@@ -1,15 +1,15 @@
 (in-package :sdl3)
 
-(cffi:defcenum flip-mode
+(defcenum flip-mode
   :none
   :horizontal
   :vertical)
 
-(cffi:defcenum scale-mode
+(defcenum scale-mode
   :nearest
   :linear)
 
-(cffi:defbitfield surface-flags 
+(defbitfield surface-flags 
   (:preallocated #x1)
   (:lock-needed  #x2)
   (:locked       #x3)

--- a/src/thread/type.lisp
+++ b/src/thread/type.lisp
@@ -2,13 +2,13 @@
 
 (cffi:defctype thread-id :uint64)
 
-(cffi:defcenum thread-properties
+(defcenum thread-properties
   :low
   :normal
   :high
   :time_critical)
 
-(cffi:defcenum thread-status
+(defcenum thread-status
   :unknown
   :alive
   :detached

--- a/src/time/type.lisp
+++ b/src/time/type.lisp
@@ -2,12 +2,12 @@
 
 (cffi:defctype stime :int64)
 
-(cffi:defcenum data-format 
+(defcenum data-format 
   (:yyyymmdd 0)
   (:ddmmyyyy 1)
   (:mmddyyyy 2))
 
-(cffi:defcenum time-format 
+(defcenum time-format 
   (:24hr 0)
   (:12hr 1))
 

--- a/src/touch/type.lisp
+++ b/src/touch/type.lisp
@@ -2,7 +2,7 @@
 
 (cffi:defctype touch-id :uint64)
 
-(cffi:defcenum touch-device-type
+(defcenum touch-device-type
   (:touch_device_invalid  -1)
   :touch_device_direct
   :touch_device_indirect_absolute

--- a/src/translate-type.lisp
+++ b/src/translate-type.lisp
@@ -81,3 +81,25 @@
        (export ',name)
        (export ',lsp-funs))))
 
+(defun first-or-identity (thing)
+  (if (listp thing)
+      (first thing)
+      thing))
+
+(defmacro defcenum (name-and-options &body enum-list)
+  (let ((name (first-or-identity name-and-options))
+        (keywords (mapcar #'first-or-identity enum-list)))
+    `(eval-when (:compile-toplevel :load-toplevel :execute)
+       (cffi:defcenum ,name-and-options
+         ,@enum-list)
+       (deftype ,name ()
+         `(member ,,@keywords)))))
+
+(defmacro defbitfield (name-and-options &body bitfield-list)
+  (let ((name (first-or-identity name-and-options))
+        (keywords (mapcar #'first-or-identity bitfield-list)))
+    `(eval-when (:compile-toplevel :load-toplevel :execute)
+       (cffi:defbitfield ,name-and-options
+         ,@bitfield-list)
+       (deftype ,name ()
+         `(member ,,@keywords)))))

--- a/src/translate-type.lisp
+++ b/src/translate-type.lisp
@@ -90,7 +90,7 @@
   (let ((name (first-or-identity name-and-options))
         (keywords (mapcar #'first-or-identity enum-list)))
     `(eval-when (:compile-toplevel :load-toplevel :execute)
-       (cffi:defcenum ,name-and-options
+       (defcenum ,name-and-options
          ,@enum-list)
        (deftype ,name ()
          `(member ,,@keywords)))))

--- a/src/video/type.lisp
+++ b/src/video/type.lisp
@@ -2,14 +2,14 @@
 
 (cffi:defctype window-id :uint32)
 
-(cffi:defcenum system-theme
+(defcenum system-theme
   :unknown
   :light
   :dark)
 
 (cffi:defctype display-id :uint32)
 
-(cffi:defcenum display-operation
+(defcenum display-operation
   :unknown
   :landscape
   :landscape_flipped
@@ -27,7 +27,7 @@
   (refresh-rate-denominator :int)
   (internal :pointer))
 
-(cffi:defbitfield (window-flags :uint64)
+(defbitfield (window-flags :uint64)
   (:fullscreen           #x0000000000000001)    
   (:opengl               #x0000000000000002)    
   (:occluded             #x0000000000000004)    
@@ -54,12 +54,12 @@
   (:transparent          #x0000000040000000)    
   (:not-focusable        #x0000000080000000))
 
-(cffi:defcenum flash-operation
+(defcenum flash-operation
   :cancel
   :briefly
   :until-focused)
 
-(cffi:defcenum glattr
+(defcenum glattr
   :red-size
   :green-size                  
   :blue-size                   


### PR DESCRIPTION
This makes finding documentation and using enums and bitfields easier. Following things will work:
- describe (e.g. `(describe #'sdl3::init-flags)`) shows the corresponding documentation and allowed keywords for the enums and bitfields
- M-. (sly-edit-definition) jumps to the location where the enum is defined. So while looking at function definition if one of its argument is enum, one can directly jump to the definition of the enum

Also, if they want, this allows users to assert types in their own functions.