### PR TITLE
Add corresponding lisp types for unions and defctype

### DIFF
--- a/src/atomic/type.lisp
+++ b/src/atomic/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defctype spin-lock :int)
+(defctype spin-lock :int)
 
 (deflsp-type atomic-int
   (value :int))

--- a/src/audio/type.lisp
+++ b/src/audio/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defctype audio-device-id :uint32)
+(defctype audio-device-id :uint32)
 
 (defcenum audio-format
   (:unknown  #x0000)

--- a/src/camera/type.lisp
+++ b/src/camera/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defctype camera-id :uint32)
+(defctype camera-id :uint32)
 
 (deflsp-type camera-spec
   (format pixel-format)

--- a/src/events/type.lisp
+++ b/src/events/type.lisp
@@ -236,7 +236,7 @@
   (mouse-x :float)
   (mouse-y :float))
 
-(cffi:defctype joystick-id :uint32)
+(defctype joystick-id :uint32)
 (deflsp-type joy-device-event
   (type event-type)
   (reserved :uint32)
@@ -381,8 +381,8 @@
   (data1 :pointer)
   (data2 :pointer))
 
-(cffi:defctype touch-id :uint64)
-(cffi:defctype finger-id :uint64)
+(defctype touch-id :uint64)
+(defctype finger-id :uint64)
 (deflsp-type touch-finger-event
   (type event-type)
   (reserved :uint32)
@@ -396,7 +396,7 @@
   (pressure :float)
   (window-id window-id))
 
-(cffi:defctype pen-id :uint32)
+(defctype pen-id :uint32)
 (deflsp-type pen-proximity-event
   (type event-type)
   (reserved :uint32)

--- a/src/events/type.lisp
+++ b/src/events/type.lisp
@@ -493,7 +493,7 @@
   (num-mime-types :int32)
   (mime-types (:pointer :string)))
 
-(cffi:defcunion event
+(defcunion event
   (type :uint32)
   (common (:struct common-event))
   (display (:struct display-event))

--- a/src/gamepad/type.lisp
+++ b/src/gamepad/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defctype joystick-id :uint32)
+(defctype joystick-id :uint32)
 
 (defcenum gamepad-type
   (:unknown 0)

--- a/src/gamepad/type.lisp
+++ b/src/gamepad/type.lisp
@@ -35,7 +35,7 @@
 (deflsp-type %gamepad-biding-input-hat
   (hat :int)
   (hat-mask :int))
-(cffi:defcunion %gamepad-binding-input
+(defcunion %gamepad-binding-input
   (buttong :int)
   (axis (:struct %gamepad-biding-input-axis))
   (hat (:struct %gamepad-biding-input-hat)))
@@ -78,11 +78,13 @@
   :left-trigger
   :right-trigger
   :count)
-(cffi:defcunion %gamepad-binding-output
-  (buttong gamepad-button)
+(deflsp-type %gamepad-binding-output-axis
   (axis gamepad-axis)
   (axis-min :int)
   (axis-max :int))
+(defcunion %gamepad-binding-output
+  (buttong gamepad-button)
+  (axis (:struct %gamepad-binding-output-axis)))
 
 (deflsp-type gamepad-binding
   (input-type gamepad-binding-type)

--- a/src/haptic/type.lisp
+++ b/src/haptic/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defctype haptic-id :uint32)
+(defctype haptic-id :uint32)
 
 (deflsp-type haptic-direction
   (type :uint8)

--- a/src/haptic/type.lisp
+++ b/src/haptic/type.lisp
@@ -85,7 +85,7 @@
   (fade-length :int16)
   (fade-level :int16))
 
-(cffi:defcunion haptic-effect
+(defcunion haptic-effect
   (type :uint16)
   (constant (:struct haptic-constant))
   (periodic (:struct haptic-periodic))

--- a/src/keyboard/type.lisp
+++ b/src/keyboard/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defctype keyboard-id :uint32)
+(defctype keyboard-id :uint32)
 
 (defcenum scancode
   (:unknown 0)

--- a/src/mouse/type.lisp
+++ b/src/mouse/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defctype mouse-id :uint32)
+(defctype mouse-id :uint32)
 
 (defbitfield mouse-button-flags
   (:button-left 1)

--- a/src/properties/type.lisp
+++ b/src/properties/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defctype properties-id :uint32)
+(defctype properties-id :uint32)
 
 (defcenum property-type
   :invalid

--- a/src/sensor/type.lisp
+++ b/src/sensor/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defctype sensor-id :uint32)
+(defctype sensor-id :uint32)
 
 (defcenum sensor-type 
   (:invalid -1)

--- a/src/storage/type.lisp
+++ b/src/storage/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defctype properties-id :uint32)
+(defctype properties-id :uint32)
 
 (deflsp-type storage-interface
   (version :uint32)

--- a/src/thread/type.lisp
+++ b/src/thread/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defctype thread-id :uint64)
+(defctype thread-id :uint64)
 
 (defcenum thread-properties
   :low

--- a/src/time/type.lisp
+++ b/src/time/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defctype stime :int64)
+(defctype stime :int64)
 
 (defcenum data-format 
   (:yyyymmdd 0)

--- a/src/timer/type.lisp
+++ b/src/timer/type.lisp
@@ -1,3 +1,3 @@
 (in-package :sdl3)
 
-(cffi:defctype timer-id :uint32)
+(defctype timer-id :uint32)

--- a/src/touch/type.lisp
+++ b/src/touch/type.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defctype touch-id :uint64)
+(defctype touch-id :uint64)
 
 (defcenum touch-device-type
   (:touch_device_invalid  -1)

--- a/src/translate-type.lisp
+++ b/src/translate-type.lisp
@@ -103,3 +103,34 @@
          ,@bitfield-list)
        (deftype ,name ()
          `(member ,,@keywords)))))
+
+(defun convert-ctype-to-lisp (typespec)
+  "Convert CFFI type specifier to lisp one.
+This doesn't handle all cases but works fine for our use."
+  (cond ((keywordp typespec) ;; basic types
+         (ecase typespec
+           ((:int :int8 :int16 :int32 :int64) 'integer)
+           ((:uint :uint8 :uint16 :uint32 :uint64) 'unsigned-byte)))
+        ((eql (first typespec) :struct)
+         ;; Since all structs in this library are defined by deflsp-type
+         ;; struct have their corresponding lisp type with same name
+         (assert (find-class (second typespec)))
+         (second typespec))
+        (t (error "Can't convert ~a to lisp type" typespec))))
+
+(defmacro defcunion (name-and-options &body union-list)
+  (let ((name (first-or-identity name-and-options)))
+    `(eval-when (:compile-toplevel :load-toplevel :execute)
+       (cffi:defcunion ,name-and-options
+         ,@union-list)
+       (deftype ,name ()
+         '(or ,@(remove-duplicates
+                 ;; skip the first field of the union
+                 ;; and convert all else to lisp type
+                 (loop for spec in (rest union-list)
+                       for array-size = (getf (nthcdr 2 spec) :count nil)
+                       for lisp-type = (convert-ctype-to-lisp (second spec))
+                       when (and lisp-type array-size)
+                         collect `(array ,lisp-type (,array-size))
+                       when (and lisp-type (not array-size))
+                         collect lisp-type)))))))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -1,7 +1,5 @@
 (in-package :sdl3)
 
-(cffi:defctype size-t #. (if (= 4 (cffi:foreign-type-size :pointer)) :uint32 :uint64))
-
 (defun create-symbol (&rest names)
   (values (intern (format nil "~{~a~}" names))))
 

--- a/src/video/type.lisp
+++ b/src/video/type.lisp
@@ -1,13 +1,13 @@
 (in-package :sdl3)
 
-(cffi:defctype window-id :uint32)
+(defctype window-id :uint32)
 
 (defcenum system-theme
   :unknown
   :light
   :dark)
 
-(cffi:defctype display-id :uint32)
+(defctype display-id :uint32)
 
 (defcenum display-operation
   :unknown

--- a/src/vulkan/func.lisp
+++ b/src/vulkan/func.lisp
@@ -1,6 +1,6 @@
 (in-package :sdl3)
 
-(cffi:defctype vk-surface-khr
+(defctype vk-surface-khr
   #. (if (= 8 (cffi:foreign-type-size :pointer))
 	 :pointer
 	 :uint64))


### PR DESCRIPTION
This adds the following benefits:
- This helps in jumping to symbol definitions (e.g. if we want to know
what subtypes are  included in sdl3:event type then we can jump to the
definition of sdl3:event using Ctrl-. in Emacs).
- (describe 'sdl3:event) gives helpful information
- You can use write type asserts for unions and type aliases