### PR TITLE
Match SDL3 `color-component-flags` size

### DIFF
--- a/src/gpu/type.lisp
+++ b/src/gpu/type.lisp
@@ -298,7 +298,7 @@
  :min
  :max)
 
-(defbitfield color-component-flags
+(defbitfield (color-component-flags :uint8)
   (:r #x1)
   (:g #x2)
   (:b #x4)


### PR DESCRIPTION
`defbitfield` without a base-type defaults to `uint` when it's [uint8](https://github.com/libsdl-org/SDL/blob/6583134365a17b0a32f31f342bbee31b7be526fa/include/SDL3/SDL_gpu.h#L1259C1-L1259C42) for `color-component-flags`, leading to issues with e.g. incorrect struct layout for SDL_GPUColorTargetBlendState.
